### PR TITLE
Usage improvements plus expand Hotspot to full LoraGw struct

### DIFF
--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,11 +1,9 @@
-use super::PublicKey;
-
 use std::result::Result;
 
 pub mod file;
 
 pub trait KeyTrait {
     type Error: core::fmt::Debug + core::fmt::Display;
-    fn pubkey(&self) -> Result<PublicKey, Self::Error>;
+    fn pubkey(&self) -> Result<helium_crypto::public_key::PublicKey, Self::Error>;
     fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use helium_proto::{mapper_payload, MapperMsg, MapperMsgV1};
 
-pub use helium_crypto::public_key::PublicKey;
-use helium_crypto::Verify;
+pub use helium_crypto;
+use helium_crypto::{public_key::PublicKey, Verify};
 
 mod cell_attach;
 pub use cell_attach::*;
@@ -71,7 +71,7 @@ pub enum Error {
         signature: Vec<u8>,
     },
     #[error("helium proto encode error: {0}")]
-    HeliumProtoEncode(#[from] helium_proto::EncodeError),
+    HeliumProtoEncode(#[from] EncodeError),
     #[error("key error: {0}")]
     Key(String), // String avoids making all of these API require the KeyTrait definition
     #[error("invalid vec size for parsing payload \"{payload}\": {size}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,15 +88,13 @@ impl TryFrom<mapper_payload::Message> for Payload {
     }
 }
 
-impl TryFrom<Payload> for mapper_payload::Message {
-    type Error = Error;
-
-    fn try_from(payload: Payload) -> std::result::Result<Self, Self::Error> {
+impl From<Payload> for mapper_payload::Message {
+    fn from(payload: Payload) -> Self {
         match payload {
-            Payload::Beacon(beacon) => Ok(beacon.into()),
-            Payload::CellAttach(attach) => Ok(attach.into()),
-            Payload::CellScan(scan) => Ok(scan.into()),
-            Payload::Gps(gps) => Ok(gps.into()),
+            Payload::Beacon(beacon) => beacon.into(),
+            Payload::CellAttach(attach) => attach.into(),
+            Payload::CellScan(scan) => scan.into(),
+            Payload::Gps(gps) => gps.into(),
         }
     }
 }
@@ -138,7 +136,7 @@ impl Message {
     ) -> std::result::Result<Self, Error> {
         let mut payload_bytes = Vec::new();
         let payload_proto = helium_proto::MapperPayload {
-            message: Some(payload.clone().try_into()?),
+            message: Some(payload.clone().into()),
         };
         payload_proto.encode(&mut payload_bytes)?;
         let signature = key

--- a/src/lora_gw.rs
+++ b/src/lora_gw.rs
@@ -1,0 +1,104 @@
+use super::{Error, Result, PublicKey};
+use rust_decimal::Decimal;
+use helium_proto::DataRate;
+
+/*
+message hotspot {
+  bytes pubkey = 1;
+  uint64 h3_cell = 2;
+  // snr in 0.1 dB
+  uint32 snr = 3;
+  // rssi in 0.1 dBm
+  int32 rssi = 4;
+  // frequency in mHz
+  int32 frequency = 5;
+  data_rate data_rate = 6;
+}
+ */
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoraGw {
+    pub pubkey: PublicKey,
+    pub h3_cell: h3o::CellIndex,
+    pub snr: Decimal,
+    pub rssi: Decimal,
+    pub frequency: Decimal,
+    pub data_rate: DataRate,
+}
+
+
+impl TryFrom<helium_proto::LoraGw> for LoraGw {
+    type Error = Error;
+    fn try_from(value: helium_proto::LoraGw) -> Result<Self> {
+        Ok(LoraGw {
+            pubkey: PublicKey::try_from(value.pubkey.clone())
+                .map_err(|error| Error::PubkeyParse { error, bytes: value.pubkey })?,
+            h3_cell: h3o::CellIndex::try_from(value.h3_cell)?,
+            snr: snr::from_proto_units(value.snr),
+            rssi: rssi::from_proto_units(value.rssi),
+            frequency: frequency::from_proto_units( value.frequency),
+            data_rate: DataRate::from_i32(value.data_rate).ok_or(Error::InvalidDatarate(value.data_rate))?,
+        })
+    }
+}
+
+impl From<LoraGw> for helium_proto::LoraGw {
+    fn from(value: LoraGw) -> Self {
+        helium_proto::LoraGw {
+            pubkey: value.pubkey.to_vec(),
+            h3_cell: value.h3_cell.into(),
+            snr: snr::to_proto_units(value.snr),
+            rssi: rssi::to_proto_units(value.rssi),
+            frequency: frequency::to_proto_units(value.frequency),
+            data_rate: value.data_rate.into(),
+        }
+    }
+}
+
+pub mod snr {
+    use super::*;
+
+    const SNR_PROTO_SCALAR: Decimal = Decimal::from_parts(1, 0, 0, false, 1);
+
+    pub fn to_proto_units(snr: Decimal) -> u32 {
+        let scaled = snr.checked_div(SNR_PROTO_SCALAR).unwrap().round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub fn from_proto_units(snr: u32) -> Decimal {
+        let snr_unscaled = Decimal::new(snr.into(), 0);
+        snr_unscaled.checked_mul(SNR_PROTO_SCALAR).unwrap()
+    }
+}
+
+pub mod rssi {
+    use super::*;
+
+    const RSSI_PROTO_SCALAR: Decimal = Decimal::from_parts(1, 0, 0, false, 2);
+
+    pub fn to_proto_units(rssi: Decimal) -> i32 {
+        let scaled = rssi.checked_div(RSSI_PROTO_SCALAR).unwrap().round();
+        scaled.to_string().parse::<i32>().unwrap()
+    }
+
+    pub fn from_proto_units(rssi: i32) -> Decimal {
+        let rssi_unscaled = Decimal::new(rssi.into(), 0);
+        rssi_unscaled.checked_mul(RSSI_PROTO_SCALAR).unwrap()
+    }
+}
+
+pub mod frequency {
+    use super::*;
+
+    const FREQUENCY_PROTO_SCALAR: Decimal = Decimal::from_parts(1, 0, 0, false, 3);
+
+    pub fn to_proto_units(frequency: Decimal) -> u32 {
+        let scaled = frequency.checked_div(FREQUENCY_PROTO_SCALAR).unwrap().round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub fn from_proto_units(frequency: u32) -> Decimal {
+        let frequency_unscaled = Decimal::new(frequency.into(), 0);
+        frequency_unscaled.checked_mul(FREQUENCY_PROTO_SCALAR).unwrap()
+    }
+}

--- a/src/lora_gw.rs
+++ b/src/lora_gw.rs
@@ -1,20 +1,6 @@
-use super::{Error, Result, PublicKey};
-use rust_decimal::Decimal;
+use super::{Error, PublicKey, Result};
 use helium_proto::DataRate;
-
-/*
-message hotspot {
-  bytes pubkey = 1;
-  uint64 h3_cell = 2;
-  // snr in 0.1 dB
-  uint32 snr = 3;
-  // rssi in 0.1 dBm
-  int32 rssi = 4;
-  // frequency in mHz
-  int32 frequency = 5;
-  data_rate data_rate = 6;
-}
- */
+use rust_decimal::Decimal;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LoraGw {
@@ -26,18 +12,22 @@ pub struct LoraGw {
     pub data_rate: DataRate,
 }
 
-
 impl TryFrom<helium_proto::LoraGw> for LoraGw {
     type Error = Error;
     fn try_from(value: helium_proto::LoraGw) -> Result<Self> {
         Ok(LoraGw {
-            pubkey: PublicKey::try_from(value.pubkey.clone())
-                .map_err(|error| Error::PubkeyParse { error, bytes: value.pubkey })?,
+            pubkey: PublicKey::try_from(value.pubkey.clone()).map_err(|error| {
+                Error::PubkeyParse {
+                    error,
+                    bytes: value.pubkey,
+                }
+            })?,
             h3_cell: h3o::CellIndex::try_from(value.h3_cell)?,
             snr: snr::from_proto_units(value.snr),
             rssi: rssi::from_proto_units(value.rssi),
-            frequency: frequency::from_proto_units( value.frequency),
-            data_rate: DataRate::from_i32(value.data_rate).ok_or(Error::InvalidDatarate(value.data_rate))?,
+            frequency: frequency::from_proto_units(value.frequency),
+            data_rate: DataRate::from_i32(value.data_rate)
+                .ok_or(Error::InvalidDatarate(value.data_rate))?,
         })
     }
 }
@@ -93,12 +83,17 @@ pub mod frequency {
     const FREQUENCY_PROTO_SCALAR: Decimal = Decimal::from_parts(1, 0, 0, false, 3);
 
     pub fn to_proto_units(frequency: Decimal) -> u32 {
-        let scaled = frequency.checked_div(FREQUENCY_PROTO_SCALAR).unwrap().round();
+        let scaled = frequency
+            .checked_div(FREQUENCY_PROTO_SCALAR)
+            .unwrap()
+            .round();
         scaled.to_string().parse::<u32>().unwrap()
     }
 
     pub fn from_proto_units(frequency: u32) -> Decimal {
         let frequency_unscaled = Decimal::new(frequency.into(), 0);
-        frequency_unscaled.checked_mul(FREQUENCY_PROTO_SCALAR).unwrap()
+        frequency_unscaled
+            .checked_mul(FREQUENCY_PROTO_SCALAR)
+            .unwrap()
     }
 }


### PR DESCRIPTION
As a rule, going from Rust native struct to proto should be infallible (9ebc6580775752de2944d7e32c1ca5fd97e70edc).

In addition, the hotspot field has gone from a simple Vec<Pubkey> to a Vec of the LoraGw struct. We've renamed it to a more specific backend name and we've also expanded upon the information contained to include radio properties and the h3 index of the hotspot.

Finally, the base of helium_crypto is exposed so the client can depend on it directly (instead of making its own import of the same crate).